### PR TITLE
Update copyright year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Andrej Karpathy
+Copyright (c) 2023 Andrej Karpathy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright year in the LICENSE file from 2022 to 2023. This change reflects the current year and ensures that the licensing information is up to date.

---

> This pull request was co-created with Cosine Genie

Original Task: [nanoGPT/0rjumpcde9l8](https://cosine.wtf/samstenner2/nanoGPT/task/0rjumpcde9l8)
Author: Sam Stenner
